### PR TITLE
esxdos support and ZX Next support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ endif
 
 export PATH:=/cygdrive/c/Hwdev/sjasmplus/:/cygdrive/e/Emulation/ZX Spectrum/Emuls/Es.Pectrum/:${PATH}
 
-SJOPTS = --nologo --fullpath --outprefix=build/ -DVERSION_DEF=\"${VERSION}\" -DVERSIONSHORT_DEF=\"${VERSIONSHORT}\"
+SJOPTS = --nologo --fullpath --outprefix=build/ -DVERSION_DEF=\"${VERSION}\" -DVERSIONSHORT_DEF=\"${VERSIONSHORT}\" $(OPTS)
 
 .PHONY: all clean run
 

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ SJOPTS = --nologo --fullpath --outprefix=build/ -DVERSION_DEF=\"${VERSION}\" -DV
 all:
 	@mkdir -p build
 	sjasmplus --msg=war --lst=build/main.lst --exp=build/main.exp --sld=build/main.sld ${SJOPTS} src/main.asm
+	sjasmplus --msg=war --lst=build/assets.lst ${SJOPTS} src/assets.asm
 	sjasmplus --msg=err --lst=build/build.lst ${SJOPTS} src/build.asm
 
 clean:

--- a/Makefile.local
+++ b/Makefile.local
@@ -1,0 +1,28 @@
+#
+
+SOURCES = $(shell find src -name '*.asm')
+SRCS_BLD = $(shell find src -name 'build*.asm)
+
+bundle: build/main.lst build/main.gfx build/build.lst
+
+build/main.lst: $(SOURCES) | build
+	sjasmplus --msg=war --lst=build/main.lst --exp=build/main.exp --sld=build/main.sld ${SJOPTS} src/main.asm
+
+build/main.gfx: src/assets.asm  | build
+	sjasmplus --msg=war --lst=build/assets.lst ${SJOPTS} src/assets.asm
+
+build/build.lst: $(SRC_BLD) | build
+	sjasmplus --msg=err --lst=build/build.lst ${SJOPTS} src/build.asm
+
+build:
+	mkdir -p $@
+
+esxdos: SJOPTS += -DDOS_ESXDOS
+esxdos: bundle
+
+dist: zxmidipl.zip
+
+zxmidipl.zip: build/zxmidipl.bas build/zxmidipl.esx res/test0.mid
+	zip -jr9 $@ $^
+
+# EOF vim: noet:ai:ts=8:sw=8:

--- a/Makefile.local
+++ b/Makefile.local
@@ -20,6 +20,9 @@ build:
 esxdos: SJOPTS += -DDOS_ESXDOS
 esxdos: bundle
 
+next: SJOPTS += -DZXNEXTOS -DDOS_ESXDOS
+next: bundle
+
 dist: zxmidipl.zip
 
 zxmidipl.zip: build/zxmidipl.bas build/zxmidipl.esx res/test0.mid

--- a/make.bat
+++ b/make.bat
@@ -5,5 +5,6 @@
 @PATH=C:\Hwdev\sjasmplus\;%PATH%
 @md build
 sjasmplus --outprefix=build/ --exp=build/main.exp -DVERSION_DEF=\"\" -DVERSIONSHORT_DEF=\"\"  src/main.asm
+sjasmplus --outprefix=build/ src/assets.asm
 sjasmplus --outprefix=build/ --msg=err src/build.asm
 @pause

--- a/src/assets.asm
+++ b/src/assets.asm
@@ -1,0 +1,26 @@
+    ASSERT __SJASMPLUS__ >= 0x011401 ; SjASMPlus 1.20.1
+    OPT --syntax=abf
+    DEVICE ZXSPECTRUM128,stack_top
+
+; assemble runtime screens bundle to be included in various builds
+
+    include "build/main.exp"
+    includelua "lua/incbin_rle.lua"
+
+    PAGE screens_page
+    ORG screens_base
+    LUA allpass
+        sj.add_word(0)
+        sj.add_word(_c("menu_scr_gfx")) -- screen_menu_ptr
+        sj.add_word(_c("play_scr_gfx")) -- screen_play_ptr
+        sj.add_word(_c("help_scr_gfx")) -- screen_help_ptr
+        sj.insert_label("menu_scr_gfx", sj.current_address); incbin_rle("res/menu.scr")
+        sj.insert_label("play_scr_gfx", sj.current_address); incbin_rle("res/play.scr")
+        sj.insert_label("help_scr_gfx", sj.current_address); incbin_rle("res/help.scr")
+        sj.parse_line("screens_end equ $")
+    ENDLUA
+
+    DISPLAY "GFX @", screens_base, "[", /D,screens_page, "] (", /A,screens_end-screens_base, ")"
+    SAVEBIN "main.gfx", screens_base, screens_end-screens_base
+
+; EOF vim: et:ai:ts=4:sw=4:

--- a/src/build.asm
+++ b/src/build.asm
@@ -6,25 +6,13 @@
     includelua "lua/incbin_pages.lua"
     includelua "lua/incbin_rle.lua"
 
-    ; BAD: duplicated in main.asm ; move to config.inc?
-        DEFINE DOS_TRDOS
-        DISPLAY "Building *** TR-DOS ***"
+    include "build.inc"
 
 ; === SNA file ===
-    page screens_page
-    org screens_base
     lua allpass
-        sj.add_word(0)
-        sj.add_word(_c("menu_scr_sna")) -- screen_menu_ptr
-        sj.add_word(_c("play_scr_sna")) -- screen_play_ptr
-        sj.add_word(_c("help_scr_sna")) -- screen_help_ptr
-        sj.insert_label("menu_scr_sna", sj.current_address); incbin_rle("res/menu.scr")
-        sj.insert_label("play_scr_sna", sj.current_address); incbin_rle("res/play.scr")
-        sj.insert_label("help_scr_sna", sj.current_address); incbin_rle("res/help.scr")
-        sj.parse_line("screens_end equ $")
-
         incbin_pages("res/start.scr",  0, nil, 0x4000, {0})
         incbin_pages("build/main.bin", 0, nil, _c("begin"), {0})
+        incbin_pages("build/main.gfx", 0, nil, _c("screens_base"), {1})
         incbin_pages("res/test0.mid",  0, nil, 0xC000, {0,4,6,3})
     endlua
     page 0 : savesna "main.sna", main
@@ -32,6 +20,10 @@
 ; === TAP file ===
     emptytap "main.tap"
     page 0 : savetap "main.tap", main
+
+    IFDEF DOS_ESXDOS
+        include "build.esxdos.asm"
+    ENDIF
 
     IFDEF DOS_TRDOS
 ; === TRD file ===

--- a/src/build.asm
+++ b/src/build.asm
@@ -6,6 +6,9 @@
     includelua "lua/incbin_pages.lua"
     includelua "lua/incbin_rle.lua"
 
+    ; BAD: duplicated in main.asm ; move to config.inc?
+        DEFINE DOS_TRDOS
+        DISPLAY "Building *** TR-DOS ***"
 
 ; === SNA file ===
     page screens_page
@@ -18,6 +21,7 @@
         sj.insert_label("menu_scr_sna", sj.current_address); incbin_rle("res/menu.scr")
         sj.insert_label("play_scr_sna", sj.current_address); incbin_rle("res/play.scr")
         sj.insert_label("help_scr_sna", sj.current_address); incbin_rle("res/help.scr")
+        sj.parse_line("screens_end equ $")
 
         incbin_pages("res/start.scr",  0, nil, 0x4000, {0})
         incbin_pages("build/main.bin", 0, nil, _c("begin"), {0})
@@ -29,7 +33,7 @@
     emptytap "main.tap"
     page 0 : savetap "main.tap", main
 
-
+    IFDEF DOS_TRDOS
 ; === TRD file ===
 ramtop equ #5fb3
     assert begin > ramtop
@@ -48,6 +52,7 @@ boot_b:
     di                                    ;
     ld a, #10 + screens_page              ; load all screens, they will be unpacked on demand
     ld bc, #7ffd                          ; ...
+    ld (bankm), a                         ; ...
     out (c), a                            ; ...
     ld hl, screens_base                   ; ...
     ld b, screen_sectors                  ; ...
@@ -59,6 +64,7 @@ boot_b:
     out (#fe), a                          ; ...
     ld a, #10                             ; code
     ld bc, #7ffd                          ; ... load
+    ld (bankm), a                         ; ...
     out (c), a                            ; ...
     ld hl, #c000                          ; ...
     ld b, code_sectors                    ; ...
@@ -123,3 +129,4 @@ boot_b_end:
             _pc(string.format("savetrd \"main.trd\", \"%s\", 0, $", file_name))
         end
     endlua
+    ENDIF;DOS_TRDOS

--- a/src/build.esxdos.asm
+++ b/src/build.esxdos.asm
@@ -1,4 +1,7 @@
-;
+; Copyright 2024 TIsland Crew
+; SPDX-License-Identifier: GPL-3.0+
+
+; this file should be included by the build.asm
 
 ; === esxDOS ===
     PAGE 0

--- a/src/build.esxdos.asm
+++ b/src/build.esxdos.asm
@@ -1,0 +1,129 @@
+;
+
+; === esxDOS ===
+    PAGE 0
+
+F_OPEN      equ 0x9a
+F_CLOSE     equ 0x9b
+F_READ      equ 0x9d
+esx_mode_read           equ $01 ; request read access
+esx_mode_use_header     equ $40 ; read/write +3DOS header
+esx_mode_open_exist     equ $00 ; only open existing file
+
+    MACRO ESXDOSCALL api
+        rst 0x08
+        db api
+    ENDM ;ESXDOSCALL
+
+    ; pack all binaries in one bundle
+
+    PAGE 0
+    OUTPUT "zxmidipl.esx"   ; building the bundle
+    ORG 0
+esx_screen:
+    incbin "res/start.scr"
+esx_main:
+    incbin "build/main.bin"
+esx_gfx:
+    incbin "build/main.gfx"
+esx_end:
+    OUTEND
+
+    MACRO NUM val
+        db 0x0E, 0x00, 0x00: dw val : db 0x00
+    ENDM ;NUM
+
+; when building BASIC loader absolute address in memory is not important
+
+    DEFINE RAMTOP   0x5fff
+    DEFINE ESXBOOT  0x5b00
+
+esx_boot_begin:
+    dw 0x0100, esx_boot_end-$-4     ; BASIC line 1 + length
+    db 0xFD, '0' : NUM RAMTOP       ; CLEAR RAMTOP
+    db ':', 0xF9, 0xC0, '('         ; : RANDOMIZE USR (
+    db '0' : NUM .bootstrap-esx_boot_begin  ; loader offset from BASIC start
+    db '+', 0xBE, '0' : NUM 23635   ; + PEEK 23635
+    db '+', '0' : NUM 256           ; + 256
+    db '*', 0xBE, '0' : NUM 23636   ; * PEEK 23636
+    db ')', ':', 0xEA               ; ) : REM
+
+.bootstrap:
+    ; BC - entry point per USR XYZ contract (.bootstrap)
+    ld hl, .payload-.bootstrap
+    add hl, bc      ; HL=absolute .payload address
+    ld de, ESXBOOT  ; payload compiled to run @ESXBOOT
+    push de         ; save launch address on stack
+    ld bc, esxloader_end-esxloader
+    ldir
+    ret             ; go to launch address
+
+.payload:
+    PHASE ESXBOOT
+esxloader:
+    ld a, '*'   ; default drive
+    ld ix, .filename
+    ld b, esx_mode_read|esx_mode_use_header|esx_mode_open_exist
+    ESXDOSCALL F_OPEN   ; AF,BC,DE,HL always NOT preserved
+    ; CF=0 - success, A - handle; CF=1 - error, A - errno
+    ret c
+    ld (.fd), a
+
+    xor a           ; ---EMbrd
+    out (0xfe), a   ; black border
+
+    ; NOTE: after F_READ we do not check if read all bytes for simplicity, however
+    ; "EOF is not an error, check BC to determine if all bytes requested were read."
+
+    ; load splash screen
+    ld a, (.fd)     ; file handle
+    ld ix, 0x4000   ; address
+    ld bc, 0x1b00   ; length
+    ESXDOSCALL F_READ   ; AF,BC,DE,HL always NOT preserved
+    ; CF=0 - success, BC - nread, HL - last read+1; CF=1 - error, BC - nread, A - errno
+    jr c, .close
+
+    ; load main code
+    ld a, (.fd)     ; file handle
+    ld ix, begin    ; address
+    ld bc, end-begin; length
+    ESXDOSCALL F_READ   ; AF,BC,DE,HL always NOT preserved
+    ; CF=0 - success, BC - nread, HL - last read+1; CF=1 - error, BC - nread, A - errno
+    jr c, .close
+
+    ; load runtime screens to bank 'screens_page'
+    ld a, 0x10+screens_page
+    ld bc, 0x7ffd
+    out (c), a      ; page in screens bank
+    ld a, (.fd)     ; file handle
+    ld ix, 0xc000   ; address
+    ld bc, esx_end-esx_gfx  ; length
+    ESXDOSCALL F_READ   ; AF,BC,DE,HL always NOT preserved
+    ; CF=0 - success, BC - nread, HL - last read+1; CF=1 - error, BC - nread, A - errno
+    ld a, 0x10
+    ld bc, 0x7ffd
+    out (c), a      ; page in bank 0 before checking F_READ status
+    jr c, .close
+
+    ; all blocks loaded without error, launch the main code
+    ld hl, main     ; save launch address on stack
+    ex (sp), hl
+
+.close:
+.fd equ $+1
+    ld a, 0xde ; SMC    ; file handle
+    ESXDOSCALL F_CLOSE  ; AF,BC,DE,HL always NOT preserved
+    ret             ; 'main' if there were no errors, caller otherwise
+.filename:  defb "zxmidipl.esx", 0
+esxloader_end:
+    UNPHASE
+    db 0x0d ; BASIC line end
+esx_boot_end:
+    DISPLAY "ESX Loader @", ESXBOOT, " (", esxloader_end-esxloader, ")"
+
+    UNDEFINE ESXBOOT
+    UNDEFINE RAMTOP
+
+    SAVE3DOS "zxmidipl.bas",esx_boot_begin,esx_boot_end-esx_boot_begin,0,1
+
+; EOF vim: et:ai:ts=4:sw=4:

--- a/src/build.inc
+++ b/src/build.inc
@@ -1,0 +1,53 @@
+;
+
+    IFNDEF _PLATFORM_
+        ; make sure only one target platform is enabled
+        IFDEF DOS_TRDOS
+            IFDEF DOS_PLUS3
+                UNDEFINE DOS_PLUS3
+            ENDIF
+            IFDEF DOS_ESXDOS
+                UNDEFINE DOS_ESXDOS
+            ENDIF
+            DEFINE _PLATFORM_
+        ENDIF;DOS_TRDOS
+
+        IFDEF DOS_PLUS3
+            IFDEF DOS_TRDOS
+                UNDEFINE DOS_TRDOS
+            ENDIF
+            IFDEF DOS_ESXDOS
+                UNDEFINE DOS_ESXDOS
+            ENDIF
+            DEFINE _PLATFORM_
+        ENDIF;DOS_PLUS3
+
+        IFDEF DOS_ESXDOS
+            IFDEF DOS_TRDOS
+                UNDEFINE DOS_TRDOS
+            ENDIF
+            IFDEF DOS_PLUS3
+                UNDEFINE DOS_PLUS3
+            ENDIF
+            DEFINE _PLATFORM_
+        ENDIF;DOS_ESXDOS
+    ENDIF;!_PLATFORM_
+
+    ; no explicit selection, fall back to TR-DOS
+    IFNDEF _PLATFORM_
+        DEFINE DOS_TRDOS
+        DEFINE _PLATFORM_
+    ENDIF;!_PLATFORM_
+
+    IFDEF DOS_TRDOS
+        DISPLAY "Platform: *** TR-DOS ***"
+    ENDIF
+    IFDEF DOS_PLUS3
+        DISPLAY "Platform: *** +3 DOS ***"
+    ENDIF
+    IFDEF DOS_ESXDOS
+        DISPLAY "Platform: *** esxDOS ***"
+    ENDIF
+
+
+; EOF vim: et:ai:ts=4:sw=4:syntax=asm:

--- a/src/disk.asm
+++ b/src/disk.asm
@@ -42,6 +42,7 @@ file_get_next_byte:
     ld c, a                          ; ...
     ld a, (bc)                       ; ...
     ld bc, #7ffd                     ;
+    ld (bankm), a                    ;
     out (c), a                       ;
 .get:
     ld a, h                          ; position = position[5:0]
@@ -56,6 +57,9 @@ file_get_next_byte:
 
 disk_sector_size equ 512
 
+; added to .driver field to mark devices without a valid filesystem
+DISK_DRIVER_NOFS_MASK   equ #08
+DISK_DRIVER_TRDOS       equ #00
 DISK_DRIVER_DIVMMC      equ #10
 DISK_DRIVER_ZXMMC       equ #20
 DISK_DRIVER_ZCONTROLLER equ #30
@@ -67,14 +71,14 @@ DISK_DRIVER_SMUC        equ #70 | #80
 driver         DB
 offset         DD
 disk_param     DB
+label          DB
 fatfs          fatfs_disk_t
-_reserv        BLOCK 1, 0
     ENDS
     STRUCT disks_t
-boot_n         DB
-current_n      DB
-current_ptr    DW
-count          DB
+boot_n         DB   ; boot disk ID, depends on the OS
+current_n      DB   ; selected disk number
+current_ptr    DW   ; pointer to the current disk in .all
+count          DB   ; number of disks found
 all            BLOCK disk_t*DISKS_MAX_COUNT
     ENDS
 
@@ -148,7 +152,18 @@ disks_scan_filesystems:
     ld (var_disk.offset+0), hl         ;
     push bc                            ;
     call fatfs_init                    ;
-    call z, disks_save_new             ;
+    jr nz, .no_fs
+    ; partition entry, assign name to be 'A'+idx
+    ld a, (var_disk.driver)
+    and 0x01    ; unit number
+    ; .3 rrca     ; 'A'-'D' for unit 0, 'a'-'d' for unit 1
+    .2 rlca     ; 'A'-'D' for unit 0, 'E'-'H' for unit 1
+    add 'A'
+    add ixh
+    ld hl, var_disk.label
+    ld (hl), a
+    call disks_save_new                ;
+.no_fs:
     pop bc                             ;
     djnz .check_partition_filesystem   ;
     ret                                ;
@@ -169,7 +184,7 @@ disks_scan_filesystems:
     or (hl)                            ; ...
     ret z                              ; ...
     pop ix                             ; return address
-1:  ex de, hl                          ; save PT_LbaOfs
+    ex de, hl                          ; save PT_LbaOfs
     ld e, (hl) : inc hl                ; ...
     ld d, (hl) : inc hl                ; ...
     push de                            ; ...
@@ -196,9 +211,7 @@ disks_scan_mmc:
     call disks_scan_filesystems        ;
     xor a : or ixh                     ; if there is no filesystems on disk - add it anyway, but deny any access to it
     ret nz                             ;
-    ld a, #01                          ; ...
-    ld (var_disk.driver), a            ; ...
-    jp disks_save_new                  ; ...
+    jr _disks_scan_no_fs
 
 
 ; IN  -  A - driver | disk_number
@@ -217,9 +230,52 @@ disks_scan_ide:
     call disks_scan_filesystems        ;
     xor a : or ixh                     ; if there is no filesystems on disk - add it anyway, but deny any access to it
     ret nz                             ;
-    ld a, #81                          ; ...
+    ;jr disks_scan_no_fs               ; fall through
+
+; no valid filesystem found on the device
+; add it anyway, but deny any access to it
+_disks_scan_no_fs:
+    ld a, (var_disk.driver)
+    or DISK_DRIVER_NOFS_MASK
     ld (var_disk.driver), a            ; ...
+    ld a, '-'
+    ld (var_disk.label), a
     jp disks_save_new                  ; ...
+
+    IFDEF DOS_TRDOS
+disks_scan_trdos:
+    ; TODO: code similar to _disk_save_device_name_a, merge?
+    assert disk_t == 16
+    ; that "cleanup" code below must be present somewhere, surely :)
+    ; cleanup var_disk, fill in relevant fields, call disks_save_new
+    ld hl, var_disk
+    ld de, var_disk+1
+    ld bc, disk_t
+    xor a
+    ld (hl), a
+    ldir
+    ; prefill driver field, it is not going to change
+    ld a, DISK_DRIVER_TRDOS
+    ld (var_disk.driver), a
+    ;
+    ld b, trdos_disks   ; counter for djnz loop
+    ld a, 'A'           ; first device name
+.loop:
+    ld hl, var_disk.label
+    ld (hl), a
+    ; we use disk_param for "target drive" when switching
+    ; and keep label as UI element only
+    ld hl, var_disk.disk_param
+    ld (hl), a
+    push af
+    push bc
+    call disks_save_new ; counter in the ixh
+    pop bc
+    pop af
+    inc a
+    djnz .loop
+    ret
+    ENDIF;DOS_TRDOS
 
 
 ; OUT - AF - garbage
@@ -232,12 +288,13 @@ disks_init:
     ld (var_disks.count), a            ;
     ld (var_disks.current_ptr+0), a    ;
     ld (var_disks.current_ptr+1), a    ;
+    IFDEF DOS_TRDOS
 .scan_trdos:
     ld a, (var_trdos_present)          ;
     or a                               ;
     jr z, .scan_divide                 ;
-    ld a, trdos_disks                  ;
-    ld (var_disks.count), a            ;
+    call disks_scan_trdos
+    ENDIF;DOS_TRDOS
 .scan_divide:
     ld a, (var_settings.divide)        ;
     or a                               ;
@@ -402,7 +459,9 @@ disk_change:
     ldir                                     ; ...
     ld a, (var_disk.driver)                  ; determine driver type
     or a                                     ; ...
+    IFDEF DOS_TRDOS
     jr z, .trd                               ; ...
+    ENDIF;DOS_TRDOS
 .fat:
     ld hl, fatfs_entry_is_directory          ;
     ld (disk_entry_is_directory+1), hl       ;
@@ -416,6 +475,7 @@ disk_change:
     jp m, ide_driver_select                  ; ... check bit 7
 .mmc:
     jp mmc_driver_select                     ; ...
+    IFDEF DOS_TRDOS
 .trd:
     ld hl, trdos_entry_is_directory          ;
     ld (disk_entry_is_directory+1), hl       ;
@@ -429,8 +489,7 @@ disk_change:
     ld (var_disks.current_ptr), hl           ;
     xor a                                    ; set Z flag
     ret                                      ;
-
-
+    ENDIF;DOS_TRDOS
 
 ; IN  - HL - pointer to file extension
 ; OUT -  A - icon
@@ -475,17 +534,31 @@ disks_get_icon_by_extension:
 ; OUT - HL - garbage
 disks_menu_generator:
     ld ix, tmp_menu_string              ;
-    ld a, 'A'                           ;
-    add a, e                            ;
-    ld (ix+1), a                        ;
-    ld (ix+2), ':'                      ;
-    ld (ix+3), 0                        ;
-.icon:
+    push de
     assert disk_t == 16
     ld h, 0 : ld l, e                   ; de = &disks.all[count]
     .4 add hl, hl                       ; ...
     ld de, var_disks.all                ; ...
     add hl, de                          ; ...
+.device:
+    call .fill.type
+    push hl
+    ld de, disk_t.label
+    add hl, de
+    ld a, (hl)
+    pop hl
+    pop de
+    or a
+    jr nz, .name
+    ld a, (hl)  ; driver
+    and 0x01    ; lower bit - unit number
+    add '0'
+.name:
+    ; TODO: check partition offset, add unit number at +6?
+    ld (ix+6), ' '
+    ld (ix+7), a
+    ld (ix+8), 0    ; NULL terminator
+.icon:
     ld a, (hl)                          ; determine driver type
     or a                                ; ...
     jr z, .trd                          ; ...
@@ -502,3 +575,39 @@ disks_menu_generator:
     ld (ix+0), udg_floppy               ;
     xor a                               ; set Z flag
     ret                                 ;
+.fill.type:
+        push hl
+        ld a, (hl)  ; driver
+        cp DISK_DRIVER_TRDOS
+        jr nz, .other
+        ld hl, .drv.n.trdos
+        jr .fill
+.other:
+        and 0x7f    ; higher bit means IDE, but type number is unique
+        ; I wish we had NEXT's SWAPNIB :)
+        .4 srl a    ; can it be simplified?
+        ld e, a
+        ld d, 0
+        ld hl, .drv.n.index
+        .5 add hl, de
+.fill:
+        ld d, ixh : ld e, ixl
+        inc de  ; ix+1 -- name (ix+0 -- icon)
+        ld bc, 5
+        ldir
+        pop hl
+        ret
+
+;                     12345
+.drv.n.trdos:   defb 'TRDOS'
+.drv.n.plus3:   defb '+3   '
+.drv.n.index    equ .drv.n.plus3
+.drv.n.divmmc:  defb 'DVMMC'
+.drv.n.zxmmc:   defb 'ZXMMC'
+.drv.n.zc:      defb 'Z-C  '
+.drv.n.neogs:   defb 'NEOGS'
+.drv.n.divide:  defb 'DVIDE'
+.drv.n.nemoide: defb 'NEMO '
+.drv.n.smuc:    defb 'SMUC '
+;                     12345
+;.drv.n.unkn:    defb 'unkwn'

--- a/src/ide.asm
+++ b/src/ide.asm
@@ -444,3 +444,28 @@ ide_read_block:
 .err:
     or 1                                 ; set NZ flag
     ret                                  ;
+
+    IFNDEF DOS_TRDOS
+trdos_entrypoint_jump        equ #3d2f
+
+; IN -  A  - port value
+; IN  - BC - port number
+; OUT - HL - garbage
+trdos_out:
+    ld hl, #3ff0                    ; "out (c), a : ret" code in trdos rom (scorpion only!)
+    jr trdos_in.c                   ;
+
+; IN  - BC - port number
+; OUT - A  - port value
+; OUT - HL - garbage
+trdos_in:                           ;
+    ld hl, #3ff3                    ; "in a, (c) : ret" code in trdos rom (scorpion only!)
+.c: call .sub                       ;
+    ei                              ;
+    ret                             ;
+.sub:                               ;
+    push hl                         ;
+    di                              ;
+    jp trdos_entrypoint_jump        ;
+
+    ENDIF ;DOS_TRDOS

--- a/src/main.asm
+++ b/src/main.asm
@@ -7,6 +7,11 @@
     include "config.inc"
     include "layout.inc"
 
+        DEFINE DOS_TRDOS
+        DISPLAY "Building *** TR-DOS ***"
+
+bankm       equ 0x5B5C      ; Copy of last byte output to I/O port 7FFDh (32765).
+
     page 0
     org int_handler-(variables_low_end-begin)
     assert $ >= 0x6000
@@ -68,9 +73,12 @@ main:
     im 2                            ; ...
     ld a, #10                       ; page BASIC48
     ld bc, #7ffd                    ; ...
+    ld (bankm), a                   ; ...
     out (c), a                      ; ...
     call device_detect_cpu_int      ;
+    IFDEF DOS_TRDOS
     call trdos_init                 ;
+    ENDIF;DOS_TRDOS
     xor a                                         ; hide "hold space for safe mode" message
     ld b, LAYOUT_START_SAFE_MESSAGE_LEN           ; ...
     LD_ATTR_ADDRESS hl, LAYOUT_START_SAFE_MESSAGE ; ...
@@ -119,6 +127,7 @@ main:
 exit:
     xor a        ; page BASIC128
     ld bc, #7ffd ; ...
+    ld (bankm), a; ...
     out (c), a   ; ...
     ld b , #1f   ; ...
     out (c), a   ; ...
@@ -391,6 +400,7 @@ stack_bottom:
 stack_top:
 
 
+    export bankm
     export begin
     export end
     export main

--- a/src/main.asm
+++ b/src/main.asm
@@ -7,8 +7,7 @@
     include "config.inc"
     include "layout.inc"
 
-        DEFINE DOS_TRDOS
-        DISPLAY "Building *** TR-DOS ***"
+    include "build.inc"
 
 bankm       equ 0x5B5C      ; Copy of last byte output to I/O port 7FFDh (32765).
 

--- a/src/main.asm
+++ b/src/main.asm
@@ -50,6 +50,7 @@ int_im2_vector_table:
     include "fatfs.asm"
     include "disk.asm"
     include "trdos.asm"
+    include "zxnextos.asm"
     include "ide.asm"
     include "mmc.asm"
     include "settings.asm"
@@ -75,6 +76,9 @@ main:
     ld (bankm), a                   ; ...
     out (c), a                      ; ...
     call device_detect_cpu_int      ;
+    IFDEF ZXNEXTOS
+    call zxnextos_init
+    ENDIF;ZXNEXTOS
     IFDEF DOS_TRDOS
     call trdos_init                 ;
     ENDIF;DOS_TRDOS

--- a/src/menu.asm
+++ b/src/menu.asm
@@ -383,6 +383,7 @@ menu_dummy_callback:
 ; menu_debug_loop:
 ;     ld a, #1f
 ;     ld bc, #7ffd
+;     ld (bankm), a
 ;     out (c), a
 ;     ld a, #c0
 ;     call screen_select

--- a/src/nextuart.asm
+++ b/src/nextuart.asm
@@ -1,86 +1,114 @@
+;
+
+    DEFINE ZXNEXTOS_UART_FLUSH
+
 ; MIDI Out for ZX Spectrum Next, using joystick port 2 in UART mode
 ; OUT - AF - garbage
 ; OUT - BC - garbage
 ; OUT - HL - garbage
 nextuart_prepare:
-    ld bc, #243b                     ; NextReg Register Select port
+    ; see
+    ; https://gitlab.com/SpectrumNext/ZX_Spectrum_Next_FPGA/-/blob/master/cores/zxnext/ports.txt
+    ; https://gitlab.com/SpectrumNext/ZX_Spectrum_Next_FPGA/-/blob/master/cores/zxnext/nextreg.txt
+    ; for port/reg details
+    IFNDEF ZXNEXTOS ; we don't have Next specific build
+    IFDEF ZXNEXTOS_Z80N_CHECK
+        ld  a, %10000000
+        db  0xED, 0x24, 0x00, 0x00   ; mirror a : nop : nop
+        ; at this point on Next A will be 1, otherwise it's 0x80
+        dec a
+        ret nz      ; we're not on Next
+    ELSE;!ZXNEXTOS_Z80N_CHECK
+    ld bc, #243B                     ; NextReg Register Select port
     xor a                            ; Register 0 (Machine ID)
     out (c), a                       ; Select register
-    ld b, #25                        ; NextReg Data port
+    inc b ;#253B                     ; BC = NextReg Data port
     in a, (c)                        ; Read register
     and #0f                          ; Select relevant bits
     cp #0a                           ; ZX Spectrum Next machine?
     ret nz                           ; No -> break
+    ENDIF;ZXNEXTOS_Z80N_CHECK
 
     xor a                            ; Opcode for NOP
     ld (nextuart_putc), a            ; Enable UART send routine
-    ld b, #24                        ; NextReg Register Select port
+    ENDIF ;!ZXNEXTOS
+
+    IFDEF ZXNEXTOS_UART_FLUSH
+        ld bc, #243B    ; NEXTREG select port
+        ld a, 0x01      ; Core Version MM; bits 7:4 = Major; bits 3:0 = Minor
+        out (c), a      ; select NEXTREG 0x01 "Core Version"
+        inc b           ; NEXTREG read port
+        in h, (c)       ; actually read core version
+        dec b           ; NEXTREG select port
+        ld a, 0x0e      ; Core Version: sub minor
+        out (c), a      ; select NEXTREG 0x0E "Sub Minor Core Version"
+        inc b           ; NEXTREG read port
+        in l, (c)       ; actually read sub minor core version
+        ld de, 0x310a   ; 3.01.10
+        xor a           ; make sure CF = 0
+        sbc hl, de
+        jr c, .uartstup ; core < 3.01.10, leave RET in place
+        ; NOTE: A=0 after xor a above
+        ;ld a, 0x00     ; NOP opcode, replacing RET
+        ld (core_ver_patch), a
+.uartstup:
+    ENDIF;ZXNEXTOS_UART_FLUSH
+
+    ld bc, #243B                     ; BC = NextReg Register Select port
     ld a, #0b                        ; Register 11 (Joystick I/O Mode)
     out (c), a                       ; Select register
-    ld b, #25                        ; NextReg Data port
-    ld a, #b0                        ; I/O mode, UART on Joystick 2
+    inc b ;#253b                     ; BC = NextReg Data port
+    ld a, %10110000                  ; I/O mode, UART on Joystick 2
+    ;      E_MM___P "E"nabled, "M"ode 11 'uart on right joystick port',
+    ;               "P"arameter 0 'redirect esp uart0 to joystick'
+    ;               (Tx out on pin 7, Rx in from pin 9, ... )
     out (c), a                       ; Write register
-    ld b, #15                        ; UART Select port
-    ld a, #10                        ; Select UART 0, set 3 highest prescaler bits (always 0 for MIDI)
+    ld b, #15 ;#153B                 ; BC = UART Select port
+    ld a, %00010000                  ; Select UART 0, set 3 highest prescaler bits (always 0 for MIDI)
+    ;      _s_W_ppp "s"elect 0 'esp UART', "W"rite bits 2:0 to "p"rescaler
+    ;               highest prescaler bits 0                                      \/
     out (c), a                       ; Write UART settings
-    ld b, #16                        ; UART Frame port
-    ld a, #98                        ; Init TX/RX, set 8N1
+    inc b ;#163B                     ; BC = UART Frame port
+    ld a, %10011000                  ; Init TX/RX, set 8N1
+    ;      RbfSSpet "R"eset Tx/Rx modules, do not assert "b"reak, no "f"low control,
+    ;               "SS" 11 - 8 bits, no "p"arity ("e"ven), 1 s"t"op bit
     out (c), a                       ; Write UART settings
-    ld a, #18                        ; set 8N1
+    ld a, %00011000                  ; set 8N1
+    ;      rbfSSpet
     out (c), a                       ; Write UART settings
     ld b, #24                        ; NextReg Register Select port
     ld a, #11                        ; Register 17 (Video timing)
     out (c), a                       ; Select register
-    ld b, #25                        ; NextReg Data port
-    in a, (c)                        ; Read register
-    and #07                          ; Select relevant bits
-    cp 0                             ; Video timing 0? (28,0 MHz)
-    jr nz, .clock1                   ; No -> Check next timing
-    ld hl, 28000000 / 31250          ; Calculate prescaler
-    jr .clock9                       ; Set prescaler
-.clock1:
-    cp 1                             ; Video timing 1? (28,571429 MHz)
-    jr nz, .clock2                   ; No -> Check next timing
-    ld hl, 28571429 / 31250          ; Calculate prescaler
-    jr .clock9                       ; Set prescaler
-.clock2:
-    cp 2                             ; Video timing 2? (29,464286 MHz)
-    jr nz, .clock3                   ; No -> Check next timing
-    ld hl, 29464286 / 31250          ; Calculate prescaler
-    jr .clock9                       ; Set prescaler
-.clock3:
-    cp 3                             ; Video timing 3? (30,0 MHz)
-    jr nz, .clock4                   ; No -> Check next timing
-    ld hl, 30000000 / 31250          ; Calculate prescaler
-    jr .clock9                       ; Set prescaler
-.clock4:
-    cp 4                             ; Video timing 4? (31,0 MHz)
-    jr nz, .clock5                   ; No -> Check next timing
-    ld hl, 31000000 / 31250          ; Calculate prescaler
-    jr .clock9                       ; Set prescaler
-.clock5:
-    cp 5                             ; Video timing 5? (32,0 MHz)
-    jr nz, .clock6                   ; No -> Check next timing
-    ld hl, 32000000 / 31250          ; Calculate prescaler
-    jr .clock9                       ; Set prescaler
-.clock6:
-    cp 6                             ; Video timing 6? (33,0 MHz)
-    jr nz, .clock7                   ; No -> Video timing 7
-    ld hl, 33000000 / 31250          ; Calculate prescaler
-    jr .clock9                       ; Set prescaler
-.clock7:
-    ld hl, 27000000 / 31250          ; Video timing 7 (27,0 MHz)
-.clock9:
-    rl l                             ; Shift bit 7 from low byte to carry
-    rl h                             ; Shift carry to high byte, H contains now upper 7 prescaler bits
-    srl l                            ; Restore low byte, L contains now lower 7 prescaler bits
-    ld b, #14                        ; UART RX / Set prescaler port
-    ld a, h                          ; Prescaler upper 7 bits
-    or #80                           ; Set bit 7 (indentifies high byte)
-    out (c), a                       ; Write prescaler upper 7 bits
-    out (c), l                       ; Write prescaler lower 7 bits
+    inc b;#253B                      ; BC = NextReg Data port
+    in a, (c)
+    and %00000111                    ; bits 7:3 - reserved, bits 2:0 - Mode
+    ld e, a                          ; E = Mode
+    xor a                            ;
+    ld d, a                          ; now we have Mode in DE
+    ld hl, prescaler                 ; prescaler value lookup table
+    add hl, de
+    add hl, de                       ; HL+=Mode*2, prescaler entries 2 bytes long
+    ; prescaler is 17 bits long and written as follows:
+    ; lowest 7 bits into #143b (if bit7=0)
+    ;   next 7 bits into #143b (if bit7=1)
+    ;  upper 3 bits into #153b -- these are always 0 for our case, set above, see /\
+    ld b, #14 ;#143B                 ; BC = UART RX port
+    ld a, (hl)                       ; lowest byte of prescaler value
+    and %01111111                    ; write lower (bit7=0) 7 bits of prescaler
+    out (c), a                       ; send prescaler value (partial) to UART
+    ld a, (hl)                       ;
+    rla                              ; move the 8th bit of prescaler in CF
+    inc hl                           ; second byte of prescaler value
+    ld a, (hl)                       ;
+    rla                              ; shift 8th bit of prescaler into A
+    or %10000000                     ; write upper (bit=7) 7 bits of prescaler
+    out (c), a                       ; send prescaler value (partial) to UART
     ret                              ;
 
+; VGA 0   1..               ..6 + HDMI (7)
+prescaler:  dw 28000000 / 31250, 28571429 / 31250, 29464286 / 31250 ; 0 1 2
+            dw 30000000 / 31250, 31000000 / 31250, 32000000 / 31250 ; 3 4 5
+            dw 33000000 / 31250, 27000000 / 31250                   ; 6 7
 
 ; Send byte to MIDI device
 ; IN  -   A - byte to send
@@ -90,15 +118,32 @@ nextuart_prepare:
 nextuart_putc:
     ret                              ; will be replaced by NOP if ZX Next detected
                                      ; (prevents hanging in next part)
+
     ld e, a                          ; Store the byte to send
     ld bc, #133b                     ; UART TX / Status port
 .wait:
     in a, (c)                        ; Read UART status
-    and #02                          ; TX buffer full?
-    jr nz, .wait                     ; wait
+    and %00000010                    ; bit 1 = 1 if the Tx buffer is full
+    jr nz, .wait                     ; wait until buffer is empty
     out (c), e                       ; Send byte to UART TX
     ret                              ;
 
 
 nextuart_flush_txbuf:
+    IFDEF ZXNEXTOS_UART_FLUSH
+core_ver_patch:
+        ret             ; SMC placeholder, replaced with 00(NOP) for core >= 3.1.10
+    ; flush Tx buffer if core ver >= 0x310a, otherwise bit 4 is not defined
+        ld bc, #133B    ; https://wiki.specnext.dev/UART_TX
+.flshtx:in a, (c)       ; BC=ZXOS_TX
+        and %00010000   ; bit 4 = 1 if the Tx buffer is empty
+        jr z, .flshtx   ; There is NO flow control, hence "infinite" loop
+        ; without timeout is acceptable. UART will always push bytes out ASAP.
+    ENDIF;ZXNEXTOS_UART_FLUSH
     ret                              ;
+
+    ; Next UART @0xA0A0(0x009C)
+    DISPLAY "Next UART @",nextuart_prepare,"(",$-nextuart_prepare,")"
+    DISPLAY " original @0x....(0x009C)"
+
+; EOF vim: et:ai:ts=4:sw=4:

--- a/src/screen.asm
+++ b/src/screen.asm
@@ -1,8 +1,8 @@
 screens_base    equ #C000
-screens_page    equ 7
-screen_menu_ptr equ #C002
-screen_play_ptr equ #C004
-screen_help_ptr equ #C006
+screens_page    equ 1
+screen_menu_ptr equ screens_base + 2
+screen_play_ptr equ screens_base + 4
+screen_help_ptr equ screens_base + 6
 
     export screens_base
     export screens_page
@@ -16,6 +16,7 @@ screen_help_ptr equ #C006
 screen_load:
     ld a, #10 + screens_page                  ;
     ld bc, #7ffd                              ;
+    ld (bankm), a                             ;
     out (c), a                                ;
     ld e, (hl)                                ; src
     inc hl                                    ; ...
@@ -25,6 +26,7 @@ screen_load:
     call rle_unpack                           ;
     ld a, #10                                 ;
     ld bc, #7ffd                              ;
+    ld (bankm), a                             ;
     out (c), a                                ;
     ret                                       ;
 

--- a/src/settings.asm
+++ b/src/settings.asm
@@ -184,6 +184,7 @@ settings_menuentry_output:
     DW str_ts2.end
     DW str_shama.end
     DW str_neogs1053.end
+.zxnext:
     DW str_zxnext.end
 settings_menuentry_divmmc:
     DB 2

--- a/src/settings.asm
+++ b/src/settings.asm
@@ -14,7 +14,11 @@ smuc        DB
 extraram    DB
 _reserv     BLOCK 256-14, 0
     ENDS
-    assert settings_t == settings_block_size
+
+    IFDEF DOS_ESXDOS
+        DEFINE settings_block_size 256
+        INCLUDE "settings.esxdos.asm"
+    ENDIF;DOS_ESXDOS
 
     IFDEF DOS_TRDOS
         DEFINE __MODULE_SETTINGS_IO_IMPLEMENTED__
@@ -102,8 +106,13 @@ settings_load:
 settings_save:
         or 0xff
         ret
-    ELSE    ; internal DEFINE, let's limit its scope
+    ELSE ; no IO implementation for settings persitence
+        ; internal DEFINE, let's limit its scope
         UNDEFINE __MODULE_SETTINGS_IO_IMPLEMENTED__
+
+        ; check that settings_t size is alright only if IO defined
+        assert settings_t == settings_block_size
+
     ENDIF ;__MODULE_SETTINGS_IO_IMPLEMENTED__
 
 settings_apply:

--- a/src/settings.esxdos.asm
+++ b/src/settings.esxdos.asm
@@ -1,0 +1,102 @@
+;
+
+    MODULE    SETTINGS_ESXDOS
+
+__MODULE_SETTINGS_ESXDOS_BEGIN__    equ $
+
+    DEFINE __MODULE_SETTINGS_IO_IMPLEMENTED__
+
+; esxDOS API calls
+F_OPEN      equ 0x9a
+F_CLOSE     equ 0x9b
+F_READ      equ 0x9d
+F_WRITE     equ 0x9e
+
+; F_OPEN mode, any/all of:
+esx_mode_read           equ $01 ; request read access
+esx_mode_write          equ $02 ; request write access
+esx_mode_use_header     equ $40 ; read/write +3DOS header
+; plus one of:
+esx_mode_open_exist     equ $00 ; only open existing file
+esx_mode_open_creat     equ $08 ; open existing or create file
+esx_mode_creat_noexist  equ $04 ; create new file, error if exists
+esx_mode_creat_trunc    equ $0c ; create new file, delete existing
+
+    IFNDEF __MACRO_ESXDOSCALL
+        MACRO ESXDOSCALL api
+            rst 0x08
+            db api
+        ENDM ;ESXDOSCALL
+        DEFINE __MACRO_ESXDOSCALL
+    ENDIF ;__MACRO_ESXDOSCALL
+
+esx_settings_load:
+    ld a, F_READ
+    ; read access, only open existing file
+    ld b, esx_mode_read|esx_mode_open_exist
+    jr _esx_file_io
+esx_settings_save:
+    ld a, F_WRITE
+    ; write access, open existing or create file
+    ld b, esx_mode_write|esx_mode_open_creat
+    ; fall through to _esx_file_io
+
+; IN - A - API CALL, B - access mode
+; OUT -  F - Z on success, NZ on fail
+_esx_file_io:
+    ld (.api_call), a
+    ; A - drive; IX - filespecz; B - access mode; DE - 3DOS header (8), if used
+    ld a, '*'   ; default drive
+    ld ix, _esx_settings_file
+    ; B preloaded ; ld b, esx_mode_???
+    ESXDOSCALL F_OPEN   ; AF,BC,DE,HL always NOT preserved
+    ; CF=0 - success, A - handle; CF=1 - error, A - errno
+    jr c, .esx_error
+    ld (.fd), a
+
+    ; READ/WRITE: A - handle, IX - address, BC - length
+    ld ix, var_settings
+    ld bc, settings_t
+.api_call   equ $+1
+    ESXDOSCALL 0x00     ; AF,BC,DE,HL always not preserved
+    ; CF=0 - success, BC - nread, HL - last read+1; CF=1 - error, BC - nread, A - errno
+    ; CF=0 - success, BC - nwrtitten ; CF=1 - error, BC - nwritten
+    jr c, .close
+    ; EOF is not an error, check BC to determine if all bytes requested were read.
+    ld hl, settings_t
+    sbc hl, bc  ; here CF=0 due to JR C above
+    jr z, .close; requested length == n(read|written), CF=0 by definition
+    scf         ; CF=1 indicating error
+
+.close:
+    ; NOTE: AF is expected to have return status of READ/WRITE call
+    push af     ; \AF/ save READ/WRITE call status
+    ; A - handle
+.fd     equ $+1
+    ld a, 0xde  ; SMC   ; file descriptor
+    ESXDOSCALL F_CLOSE  ; AF,BC,DE,HL always not preserved
+    ; CF=0 - success, A=0; CF=1 - error, A - errno
+    jr c, .esx_error_close
+    pop af      ; /AF\ check READ/WRITE status
+    jr c, .esx_error
+
+    xor a   ; ZF=1 - SUCCESS
+    ret
+.esx_error_close:
+    pop af      ; /AF\ discard READ/WRITE status
+.esx_error:
+    or 0xff ; ZF=0 - ERROR
+    ret
+
+_esx_settings_file: defb "zxmidipl.cfg", 0
+
+__MODULE_SETTINGS_ESXDOS_SIZE__ equ $-__MODULE_SETTINGS_ESXDOS_BEGIN__
+
+    DISPLAY "settings esxDOS @",__MODULE_SETTINGS_ESXDOS_BEGIN__," size: ",__MODULE_SETTINGS_ESXDOS_SIZE__
+
+    ENDMODULE;SETTINGS_ESXDOS
+
+settings_load   equ SETTINGS_ESXDOS.esx_settings_load
+settings_save   equ SETTINGS_ESXDOS.esx_settings_save
+
+; EOF vim: et:ai:ts=4:sw=4:

--- a/src/settings.esxdos.asm
+++ b/src/settings.esxdos.asm
@@ -1,4 +1,5 @@
-;
+; Copyright 2024 TIsland Crew
+; SPDX-License-Identifier: GPL-3.0+
 
     MODULE    SETTINGS_ESXDOS
 

--- a/src/trdos.asm
+++ b/src/trdos.asm
@@ -1,3 +1,6 @@
+;
+
+    IFDEF DOS_TRDOS
 ; TR-DOS directory entry:
 ; 0......7 8 9  B  D E F
 ; NNNNNNNN T AA LL C S T
@@ -53,7 +56,12 @@ trdos_fun_select_side_0      equ #16
 trdos_fun_select_side_1      equ #17
 trdos_fun_reconfig_floppy    equ #18
 
-
+    ; it's DEFINE and not EQU because it's easier to check with IFDEF
+    IFNDEF settings_block_size
+        DEFINE settings_block_size trdos_sector_size
+    ELSE
+        ASSERT settings_block_size==trdos_sector_size
+    ENDIF;settings_block_size
 
 trdos_basic_interceptor:
     ex (sp), hl                      ;
@@ -422,3 +430,5 @@ trdos_in:                           ;
     push hl                         ;
     di                              ;
     jp trdos_entrypoint_jump        ;
+
+    ENDIF;DOS_TRDOS

--- a/src/zxnextos.asm
+++ b/src/zxnextos.asm
@@ -1,0 +1,153 @@
+; Copyright 2024 TIsland Crew
+; SPDX-License-Identifier: GPL-3.0+
+
+    IFDEF ZXNEXTOS
+
+    DISPLAY "Target:   *** ZX Next OS ***"
+
+    ; calculate ZXNET output option offset (index), see settings.asm
+    ; -1 for DB N, -2 for var_settings.output
+    ; we rely on 'settings_menuentry_output.zxnext' being defined
+    LUA
+       sj.insert_define("__SETTINGS_ZXNEXT_OUTPUT_POS__", (_c("settings_menuentry_output.zxnext")-_c("settings_menuentry_output")-1-2)//2)
+    ENDLUA
+
+zxnextos_init:
+    ; check is we have Z80N CPU, recommended way to detect Next
+    ld  a, %10000000
+    db  0xED, 0x24, 0x00, 0x00   ; mirror a : nop : nop
+    ; at this point on Next A will be 1, otherwise it's 0x80
+    dec a
+    ret nz      ; we're not on Next
+
+    ; now enable UART send routine:
+    xor a                            ; Opcode for NOP
+    ld (nextuart_putc), a            ; Enable UART send routine
+
+    ; and, finally, adjust default settings (loaded data overrides)
+    ld a, 1 ; FIXME: magic number! calculate like __SETTINGS_ZXNEXT_OUTPUT_POS__
+    ld (var_settings.divmmc), a ; force enable DivMMC
+    ld a, __SETTINGS_ZXNEXT_OUTPUT_POS__
+    ld (var_settings.output), a ; force enable Next UART
+
+    ret
+
+    IFDEF DOS_ESXDOS
+        DEFINE __ZXNEXT_IO_IMPLEMENTED__
+    ENDIF;DOS_ESXDOS
+
+    IFDEF DOS_PLUS3
+
+    DEFINE __ZXNEXT_IO_IMPLEMENTED__
+    ; this is extremely trimmed PLUS3 module, leaving only init in place
+    ; basic init is necessary for settings save/load to work
+    ; data I/O is handled by the DivMMC module, which is force enabled
+
+PLUS3.__MODULE_DOS_PLUS3__BEGIN__ equ $
+
+    MODULE      ZXNEXTOS
+p3api:
+        ld iy, (var_basic_iy)  ; restore IY
+        ; execution continues to PLUS3API.plus3api
+    INCLUDE "plus3-api.asm"
+
+    MACRO PLUS3CALL api
+        call ZXNEXTOS.p3api
+        dw api
+    ENDM
+
+disk_init:
+        ; no need to check var_plus3dos_present
+        ; the rest copied from plus3dos, default drive needed to save settings
+        ld a, 0xff  ; FFh (255) = get default drive
+        PLUS3CALL DOS_SET_DRIVE   ; BC DE HL IX corrupt
+        jr nc, 1f
+        ld (var_disks.boot_n), a
+1:
+        ; disable recoverable error reporting (interactive Retry,Abort,Cancel?)
+        xor a   ; A=0, disable error messages
+        ; A = Enable (0xff)/disable (0)
+        ; HL = Address of ALERT routine (if enabled)
+        PLUS3CALL DOS_SET_MESSAGE   ; AF BC DE IX corrupt
+        ; HL = address of previous ALERT routine (0 if none)
+
+        ; FIXME: duplicated in plus3-loader
+        ld de, 0x1b04   ; cache at bufer 0x1b, size 0x04
+        ld hl, 0x2000   ; RAMdisk at buffer 0x20, size 0x00 (OFF)
+        ; D = First buffer for cache
+        ; E = Number of cache sector buffers
+        ; H = First buffer for RAMdisk
+        ; L = Number of RAMdisk sector buffers
+        ; (Note that E + L <= 128)
+        PLUS3CALL DOS_SET_1345  ; BC DE HL IX corrupt
+        ; CF=1 - success, A - corrupt
+        ; CF=0 - error, A=error code
+        ;DEBUG: PLUS3CALL DOS_GET_1345  ; AF BC IX corrupt
+        ret
+
+disk_directory_load:
+disk_entry_is_directory:
+disk_file_load:
+disk_directory_menu_generator:
+        xor a   ; set ZF=1
+        ; intentional fall-through to RET below
+disk_enumerate_volumes:
+disk_device_change:
+        ; no op
+        ret
+
+    IFDEF __SETTINGS_ZXNEXT_OUTPUT_POS__
+    ENDIF;__SETTINGS_ZXNEXT_OUTPUT_POS__
+
+    ENDMODULE ; ZXNEXTOS
+
+PLUS3.__MODULE_DOS_PLUS3_SIZE__ equ $-PLUS3.__MODULE_DOS_PLUS3__BEGIN__
+
+    DISPLAY "ZX Next OS @",PLUS3.__MODULE_DOS_PLUS3__BEGIN__," size:",PLUS3.__MODULE_DOS_PLUS3_SIZE__
+
+    ; it's DEFINE and not EQU because it's easier to check with IFDEF
+    IFNDEF settings_block_size
+        DEFINE settings_block_size 256
+    ELSE
+        ASSERT settings_block_size==256
+    ENDIF;settings_block_size
+
+plus3_init                  equ ZXNEXTOS.disk_init
+plus3_scan_disks            equ ZXNEXTOS.disk_enumerate_volumes
+plus3_entry_is_directory    equ ZXNEXTOS.disk_entry_is_directory
+plus3_file_load             equ ZXNEXTOS.disk_file_load
+plus3_directory_load        equ ZXNEXTOS.disk_directory_load
+plus3_file_menu_generator   equ ZXNEXTOS.disk_directory_menu_generator
+
+    ; compat shim
+
+PLUS3DOS_ORG equ PLUS3.__MODULE_DOS_PLUS3__BEGIN__
+    EXPORT PLUS3DOS_ORG     ; build.asm optionally creates .drv if < 0x8000
+
+; has to be exported explicitly
+PLUS3.disk_device_change    equ ZXNEXTOS.disk_device_change
+
+PLUS3.FILENO                equ 7   ; arbitrary number, we don't keep files open
+
+PLUS3.DOS_OPEN              equ ZXNEXTOS.DOS_OPEN
+PLUS3.DOS_READ              equ ZXNEXTOS.DOS_READ
+PLUS3.DOS_WRITE             equ ZXNEXTOS.DOS_WRITE
+PLUS3.DOS_CLOSE             equ ZXNEXTOS.DOS_CLOSE
+PLUS3.DD_L_OFF_MOTOR        equ ZXNEXTOS.DD_L_OFF_MOTOR
+
+    ENDIF;DOS_PLUS3
+
+    UNDEFINE __SETTINGS_ZXNEXT_OUTPUT_POS__
+
+    IFNDEF __ZXNEXT_IO_IMPLEMENTED__
+        LUA
+            sj.warning("ZX Next OS target has no supported filesystem!")
+            sj.warning("settings persistence will not work!")
+        ENDLUA
+    ELSE  ;__ZXNEXT_IO_IMPLEMENTED__
+        UNDEFINE __ZXNEXT_IO_IMPLEMENTED__
+    ENDIF;!__ZXNEXT_IO_IMPLEMENTED__
+
+    ENDIF;ZXNEXTOS
+
+; EOF vim: et:ai:ts=4:sw=4:


### PR DESCRIPTION
This patch builds on top of [Vic's initial changes for +3 DOS](https://gitflic.ru/project/chwe/zx-midiplayer?branch=patch-plus3) support but has smaller scope and enables esxdos and ZX Next targets. It allows bypassing esxdos TR-DOS emulation and using esxdos API directly, which comes handy on the Next where its native "personality" has no TR-DOS support/emulation. On "pure" esxdos machine is enabled to break free from TRD container.

Patch tested on ZX Spectrum +2, ZX Spectrum Next and emulators.

To simplify review patch consists of three commits -- Vic's changes to make TR-DOS optional, esxdos support and ZX Next support.

[Discussion thread on SpecNext.com](https://www.specnext.com/forum/viewtopic.php?t=2556&start=20#p15877)